### PR TITLE
Make ImageID optional

### DIFF
--- a/cmd/ebctl/sboms.go
+++ b/cmd/ebctl/sboms.go
@@ -225,9 +225,6 @@ func (cli *CLI) uploadSBOM(ctx context.Context, args UploadSBOMArgs) (string, er
 	if args.ImageID != "" {
 		imageID = args.ImageID
 	}
-	if imageID == "" {
-		return "", errors.New("image ID cannot be inferred from this SBOM format, specify it with --image-id")
-	}
 
 	if args.ImageTag != "" {
 		imageTag = args.ImageTag


### PR DESCRIPTION
While --image-id was already optional, it required that the ImageID was found inside the SBOM.

This makes ImageID completely optional. While this will degrade functionality, making it impossible to map the SBOM to the workload, this can still be useful for reporting vulns on GitHub PRs.