### PR TITLE
Use goreleaser to release to S3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,15 +11,26 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: '1.20'
+
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::881267199659:role/GitHubActionsS3FullAccess
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,3 +36,14 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+blobs:
+  - provider: s3
+    region: us-east-1
+    bucket: edgebit-releases
+    folder: releases/edgebit-cli/{{.Tag}}
+
+  - provider: s3
+    region: us-east-1
+    bucket: edgebit-releases
+    folder: releases/edgebit-cli/latest


### PR DESCRIPTION
In addition to releasing to GitHub, release the binaries to S3
so that they're available via CloudFront at
https://install.edgebit.io/releases/edgebit-cli/