### PR TITLE
Fix invalidated CF paths

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,4 +42,4 @@ jobs:
         uses: chetan/invalidate-cloudfront-action@v2
         env:
           DISTRIBUTION: ${{ secrets.DISTRIBUTION }}
-          PATHS: "/edgebit-releases/releases/edgebit-cli/latest/*"
+          PATHS: "/releases/edgebit-cli/latest/*"


### PR DESCRIPTION
The paths are specified relative to the distribution, not the S3.