### PR TITLE
Ability to Fetch SBOM from OCI Registries

### DIFF
--- a/cmd/ebctl/main.go
+++ b/cmd/ebctl/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -25,9 +24,10 @@ func main() {
 	cmd.AddCommand(uploadSBOMCommandForCI())
 	cmd.AddCommand(fetchSBOMCommand())
 
+	cmd.SilenceUsage = true
+
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/ebctl/main.go
+++ b/cmd/ebctl/main.go
@@ -23,6 +23,7 @@ func main() {
 
 	cmd.AddCommand(uploadSBOMCommand())
 	cmd.AddCommand(uploadSBOMCommandForCI())
+	cmd.AddCommand(fetchSBOMCommand())
 
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {

--- a/cmd/ebctl/registry.go
+++ b/cmd/ebctl/registry.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func fetchSBOMCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fetch-sbom",
+		Short: "Fetch an SBOM",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			sbom, err := fetchSBOM(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			// Nothing really productive to do with an error here
+			_, _ = io.Copy(os.Stdout, sbom)
+
+			return nil
+		},
+		Args: cobra.ExactArgs(1),
+	}
+
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,14 @@ require (
 	connectrpc.com/connect v1.12.0
 	github.com/anchore/syft v0.94.0
 	github.com/bufbuild/buf v1.28.1
+	github.com/google/go-containerregistry v0.16.1
 	github.com/spf13/cobra v1.8.0
 	google.golang.org/protobuf v1.31.1-0.20231027082548-f4a6c1f6e5c1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 )
 
 require (
@@ -73,7 +79,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/cel-go v0.18.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/go-containerregistry v0.16.1 // indirect
 	github.com/google/pprof v0.0.0-20231101202521-4ca4178f5c7a // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/gookit/color v1.5.4 // indirect
@@ -132,6 +137,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.16.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/sylabs/sif/v2 v2.11.5 // indirect
 	github.com/sylabs/squashfs v0.6.1 // indirect

--- a/pkg/sboms/intoto.go
+++ b/pkg/sboms/intoto.go
@@ -1,0 +1,48 @@
+package sboms
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type inTotoStatement struct {
+	PredicateType string                     `json:"predicateType"`
+	Subject       []inTotoResourceDescriptor `json:"subject"`
+	Predicate     json.RawMessage            `json:"predicate"`
+}
+
+func (r *inTotoStatement) AppliesTo(digest v1.Hash) bool {
+	for _, subject := range r.Subject {
+		if subject.Digest[digest.Algorithm] == digest.Hex {
+			return true
+		}
+	}
+
+	return false
+}
+
+type inTotoResourceDescriptor struct {
+	Name   string            `json:"name"`
+	Digest map[string]string `json:"digest"`
+}
+
+type dsseEnvelope struct {
+	PayloadType string `json:"payloadType"`
+	Payload     []byte `json:"payload"`
+}
+
+func (e *dsseEnvelope) UnmarshalStatement() (*inTotoStatement, error) {
+	if e.PayloadType != "application/vnd.in-toto+json" {
+		return nil, fmt.Errorf("unsupported payload type: %s", e.PayloadType)
+	}
+
+	stmt := &inTotoStatement{}
+	err := json.Unmarshal(e.Payload, stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	return stmt, nil
+}

--- a/pkg/sboms/registry.go
+++ b/pkg/sboms/registry.go
@@ -1,0 +1,337 @@
+package sboms
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+var (
+	ErrNoSBOM          = fmt.Errorf("no SBOM found")
+	ErrSubjectMismatch = fmt.Errorf("subject mismatch")
+)
+
+type RegistryLoader struct {
+	RegistryOpts []remote.Option
+}
+
+func NewDefaultRegistryLoader(ctx context.Context) *RegistryLoader {
+	return &RegistryLoader{
+		RegistryOpts: []remote.Option{
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+			remote.WithContext(ctx),
+		},
+	}
+}
+
+// extractDockerStyleSBOM extracts an SBOM stored in a Docker-style attestation.
+//
+// We treat ref as pointing to an Index, and look for a manifest in that Index where the
+// "vnd.docker.reference.type" annotation is "attestation-manifest" and the
+// "vnd.docker.reference.digest" annotation is the digest of the target image.
+//
+// This is based on https://docs.docker.com/build/attestations/attestation-storage/
+func (r *RegistryLoader) loadDockerStyleSBOM(ctx context.Context, desc *remote.Descriptor, targetImage v1.Image) (io.ReadCloser, error) {
+	resolvedImageDigest, err := targetImage.Digest()
+	if err != nil {
+		return nil, err
+	}
+
+	index, err := desc.ImageIndex()
+	if err != nil {
+		return nil, ErrNoSBOM
+	}
+
+	idxManifest, err := index.IndexManifest()
+	if err != nil {
+		return nil, ErrNoSBOM
+	}
+
+	// Search the Index for an attestation manifest pointing to the target image.
+	for _, desc := range idxManifest.Manifests {
+		if desc.Annotations["vnd.docker.reference.type"] != "attestation-manifest" {
+			continue
+		}
+
+		if desc.Annotations["vnd.docker.reference.digest"] != resolvedImageDigest.String() {
+			continue
+		}
+
+		image, err := index.Image(desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+
+		// Found a match, return the SBOM contained in the image this manifest points to.
+		return r.loadSBOMFromImage(ctx, image, resolvedImageDigest)
+	}
+
+	return nil, ErrNoSBOM
+}
+
+// loadCosignLegacySBOM attempts to load an SBOM stored in the legacy Cosign format.
+//
+// Specifically, we search for an SBOM stored directly in a layer in an image tagged
+// 'sha256-{targetImageDigest}.sbom'.
+//
+// See: https://github.com/sigstore/cosign/blob/main/specs/SBOM_SPEC.md
+func (r *RegistryLoader) loadCosignLegacySBOM(ctx context.Context, ref name.Reference, targetImage v1.Image) (io.ReadCloser, error) {
+	subject, err := targetImage.Digest()
+	if err != nil {
+		return nil, err
+	}
+
+	sbomRef, err := buildOCIRef(ref.Context(), subject, "sbom")
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := remote.Image(sbomRef, r.RegistryOpts...)
+	if err != nil {
+		return nil, ErrNoSBOM
+	}
+
+	return r.loadSBOMFromImage(ctx, image, subject)
+}
+
+// loadCosignAttestationSBOM attempts to load an SBOM stored in the modern Cosign format.
+//
+// Specifically, we load a manifest tagged 'sha256-{targetImageDigest}.att', and look for
+// an SBOM stored in an in-toto Statement wrapped in a DSSE envelope which is stuck into
+// a layer in the image.
+//
+// In practice, these .att images seem to frequently contain dozens of layers containing
+// similar DSSE envelopes which apply to some other image, so it is critical to search
+// through them to find a Statement which identifies the target image as its Subject.
+//
+// See: https://github.com/sigstore/cosign/blob/main/specs/ATTESTATION_SPEC.md
+func (r *RegistryLoader) loadCosignAttestationSBOM(ctx context.Context, ref name.Reference, targetImage v1.Image) (io.ReadCloser, error) {
+	subject, err := targetImage.Digest()
+	if err != nil {
+		return nil, err
+	}
+
+	attestationRef, err := buildOCIRef(ref.Context(), subject, "att")
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := remote.Image(attestationRef, r.RegistryOpts...)
+	if err != nil {
+		return nil, ErrNoSBOM
+	}
+
+	return r.loadSBOMFromImage(ctx, image, subject)
+}
+
+// loadSBOMFromImage searches the given image for an SBOM stored in a layer referencing
+// the indicated subject.
+//
+// This method is common to all SBOM storage formats we support, and attempts (somewhat)
+// to be generically capable of handling any future formats we may encounter.
+func (r *RegistryLoader) loadSBOMFromImage(ctx context.Context, image v1.Image, subject v1.Hash) (io.ReadCloser, error) {
+	manifest, err := image.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, desc := range manifest.Layers {
+		switch {
+		// Handle SBOMs stored directly in a layer. Nothing about how we handle these is
+		// format-specific, so the above test can be extended in the future to support any
+		// other media type we encounter.
+		//
+		// In practice this seems to correspond exclusively to the legacy Cosign SBOM storage
+		// format.
+		case desc.MediaType == "spdx+json" || desc.MediaType == "text/spdx+json":
+
+			layer, err := image.LayerByDigest(desc.Digest)
+			if err != nil {
+				return nil, err
+			}
+
+			return layer.Uncompressed()
+
+		// Handle SBOMs stored within an in-toto Statement.
+		//
+		// This is the format used by Docker for SBOM storage. This could be extended
+		// in the storage to support other SBOM predicate types, eg CycloneDX:
+		// https://github.com/in-toto/attestation/blob/main/spec/predicates/cyclonedx.md
+		case desc.MediaType == "application/vnd.in-toto+json" &&
+			desc.Annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document":
+			layer, err := image.LayerByDigest(desc.Digest)
+			if err != nil {
+				return nil, err
+			}
+
+			sbom, err := r.extractSBOMFromStatementLayer(ctx, layer, subject)
+			if err != nil {
+				if err == ErrSubjectMismatch {
+					continue
+				} else {
+					return nil, err
+				}
+			}
+
+			return sbom, nil
+
+		// Handle SBOMs stored in an in-toto Statement wrapped in a DSSE envelope.
+		//
+		// Again, this could be extended to support other JSON formatted SBOMs such
+		// as CycloneDX:
+		// https://github.com/in-toto/attestation/blob/main/spec/predicates/cyclonedx.md
+		case desc.MediaType == "application/vnd.dsse.envelope.v1+json" &&
+			desc.Annotations["predicateType"] == "https://spdx.dev/Document":
+			layer, err := image.LayerByDigest(desc.Digest)
+			if err != nil {
+				return nil, err
+			}
+
+			sbom, err := r.extractSBOMFromEnvelopeLayer(ctx, layer, subject)
+			if err != nil {
+				if err == ErrSubjectMismatch {
+					continue
+				} else {
+					return nil, err
+				}
+			}
+
+			return sbom, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unable to find supported SBOM layer within image")
+}
+
+// extractSBOMFromEnvelopeLayer extracts an SBOM from a layer containing a DSSE envelope
+// wrapping an in-toto Statement.
+//
+// If the Statement does not identify the given subject as its Subject, ErrSubjectMismatch
+// is returned.
+func (r *RegistryLoader) extractSBOMFromEnvelopeLayer(ctx context.Context, layer v1.Layer, subject v1.Hash) (io.ReadCloser, error) {
+	data, err := layer.Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+
+	defer data.Close()
+
+	envelope := &dsseEnvelope{}
+
+	err = json.NewDecoder(data).Decode(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding DSSE envelope: %w", err)
+	}
+
+	statement, err := envelope.UnmarshalStatement()
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling DSSE statement: %w", err)
+	}
+
+	if !statement.AppliesTo(subject) {
+		return nil, ErrSubjectMismatch
+	}
+
+	// It seems like some implementations (e.g. gcr.io/distroless/static) store the SBOM
+	// as a JSON string in the predicate field, rather than a JSON object.
+	//
+	// As a special case, we'll try to decode the predicate and return the underlying
+	// JSON.
+	if len(statement.Predicate) > 0 && statement.Predicate[0] == '"' {
+		var predicateJSON string
+
+		err := json.Unmarshal(statement.Predicate, &predicateJSON)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding predicate JSON string: %w", err)
+		}
+
+		return io.NopCloser(bytes.NewReader([]byte(predicateJSON))), nil
+	}
+
+	return io.NopCloser(bytes.NewReader(statement.Predicate)), nil
+}
+
+// extractSBOMFromStatementLayer extracts an SBOM from a layer containing an in-toto
+// Statement.
+//
+// If the Statement does not identify the given subject as its Subject, ErrSubjectMismatch
+// is returned.
+func (r *RegistryLoader) extractSBOMFromStatementLayer(ctx context.Context, layer v1.Layer, subject v1.Hash) (io.ReadCloser, error) {
+	data, err := layer.Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+
+	defer data.Close()
+
+	statement := &inTotoStatement{}
+
+	err = json.NewDecoder(data).Decode(statement)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding attestation Statement: %w", err)
+	}
+
+	if !statement.AppliesTo(subject) {
+		return nil, ErrSubjectMismatch
+	}
+
+	return io.NopCloser(bytes.NewReader(statement.Predicate)), nil
+}
+
+// Load attempts to locate an SBOM for the given image reference, and returns an
+// io.ReadCloser which can be used to read the raw bytes of the SBOM.
+func (r *RegistryLoader) Load(ctx context.Context, refStr string) (io.ReadCloser, error) {
+	ref, err := name.ParseReference(refStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the referenced manifest so we can get the target image.
+	desc, err := remote.Get(ref, r.RegistryOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error loading '%s': %w'", refStr, err)
+	}
+
+	// Resolve the referenced manifest to a target image.
+	targetImage, err := desc.Image()
+	if err != nil {
+		return nil, fmt.Errorf("error resolving '%s' to image: %w", refStr, err)
+	}
+
+	// Attempt to load a Docker-style SBOM.
+	data, err := r.loadDockerStyleSBOM(ctx, desc, targetImage)
+	if err != nil && err != ErrNoSBOM {
+		return nil, err
+	} else if err == nil {
+		return data, nil
+	}
+
+	// Attempt to load a legacy Cosign-style SBOM.
+	data, err = r.loadCosignLegacySBOM(ctx, ref, targetImage)
+	if err != nil && err != ErrNoSBOM {
+		return nil, err
+	} else if err == nil {
+		return data, nil
+	}
+
+	// Attempt to load a modern Cosign-style SBOM.
+	data, err = r.loadCosignAttestationSBOM(ctx, ref, targetImage)
+	if err != nil && err != ErrNoSBOM {
+		return nil, err
+	} else if err == nil {
+		return data, nil
+	}
+
+	return nil, ErrNoSBOM
+}
+
+func buildOCIRef(base name.Repository, subject v1.Hash, ext string) (name.Reference, error) {
+	return base.Tag(fmt.Sprintf("%s-%s.%s", subject.Algorithm, subject.Hex, ext)), nil
+}

--- a/pkg/sboms/registry_test.go
+++ b/pkg/sboms/registry_test.go
@@ -1,0 +1,78 @@
+package sboms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anchore/syft/syft/formats"
+	"github.com/anchore/syft/syft/formats/spdxjson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSBOM(t *testing.T) {
+	tests := []struct {
+		name        string
+		image       string
+		invalidSBOM bool
+	}{
+		{
+			// Modern Ghost image with an SBOM attached in the Docker style.
+			name:  "Ghost",
+			image: "ghost:5.75.0-alpine",
+		},
+		{
+			// Example from the Docker docs:
+			// https://github.com/docker/buildx/blob/5b5c4c8c9df55e133c39cce8153e0fa9fc6f60c4/docs/reference/buildx_imagetools_inspect.md
+			name:  "CrazyMaxBuildkit",
+			image: "index.docker.io/crazymax/buildkit@sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19",
+		},
+		{
+			// A random older (late 2022) Chainguard static base image with a .sbom
+			// attached.
+			name:        "ChainguardStaticOld",
+			image:       "cgr.dev/chainguard/static@sha256:3d7a2b4e485b98ffc9a8dc10a7c8bc82bc235f72cf166abb8058e5a65648c500",
+			invalidSBOM: true,
+		},
+		{
+			// A newer (late 2023) Chainguard static base image with a .att attestation,
+			// but not .sbom.
+			name:  "ChainguardStaticModern",
+			image: "cgr.dev/chainguard/static@sha256:606b571cf58a1f29a65ed4a09973b02664ce61a1325e8295f9ab1e38a1ac0632",
+		},
+		{
+			// Unpinned Chainguard static base image.
+			name:  "ChainguardLatest",
+			image: "cgr.dev/chainguard/static",
+		},
+		{
+			// Unpinned Distroless static base image.
+			name:  "DistrolessStaticLatest",
+			image: "gcr.io/distroless/static",
+		},
+		{
+			// Unpinned rekor-server image.
+			name:  "GCRRekor",
+			image: "gcr.io/projectsigstore/rekor-server:v1.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			loader := NewDefaultRegistryLoader(ctx)
+
+			data, err := loader.Load(ctx, tt.image)
+			require.NoError(t, err)
+
+			sbom, format, err := formats.Decode(data)
+			if tt.invalidSBOM {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, format.ID(), spdxjson.ID)
+			require.Greater(t, sbom.Artifacts.Packages.PackageCount(), 0)
+		})
+	}
+}


### PR DESCRIPTION
This does two things:

1. Extends the existing `upload-sbom` and `upload-sbom-for-ci` sub-commands to support passing an string of the form `registry:${REMOTE_OCI_REFERENCE}`, which causes the CLI to search the referenced OCI repository for an SBOM for the referenced image
2. Adds a `fetch-sbom` sub-command which takes an input of the same form as `upload-sbom`, but instead of uploading it, we just spit it to stdout

When interacting with remote OCI repositories, we use the local Docker config if there is one.