### PR TITLE
Clean up output on error

### DIFF
--- a/cmd/ebctl/main.go
+++ b/cmd/ebctl/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -19,6 +18,7 @@ func main() {
 		Use:     "ebctl",
 		Short:   "CLI for EdgeBit.io",
 		Version: version,
+		SilenceUsage: true,
 	}
 
 	cmd.AddCommand(uploadSBOMCommand())
@@ -26,7 +26,6 @@ func main() {
 
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Before this change, when an error occurred, the error would be printed out, followed by the usage information, and then followed again by the error message. Seeing the usage information tends to be misleading since it traditionally suggests a problem parsing the program arguments. This disables that behavior and removes the redundant error message.