### PR TITLE
Improve OCI Image Architecture Resolution

### DIFF
--- a/cmd/ebctl/registry.go
+++ b/cmd/ebctl/registry.go
@@ -13,7 +13,10 @@ func fetchSBOMCommand() *cobra.Command {
 		Short: "Fetch an SBOM",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			sbom, err := fetchSBOM(ctx, args[0])
+
+			resolvePlatform := cmd.Flag("resolve-platform").Value.String()
+
+			sbom, err := fetchSBOM(ctx, resolvePlatform, args[0])
 			if err != nil {
 				return err
 			}
@@ -25,6 +28,8 @@ func fetchSBOMCommand() *cobra.Command {
 		},
 		Args: cobra.ExactArgs(1),
 	}
+
+	cmd.Flags().String("resolve-platform", "", "Resolve the SBOM for the given platform (e.g. linux/amd64)")
 
 	return cmd
 }

--- a/pkg/sboms/registry_test.go
+++ b/pkg/sboms/registry_test.go
@@ -11,20 +11,33 @@ import (
 
 func TestLoadSBOM(t *testing.T) {
 	tests := []struct {
-		name        string
-		image       string
-		invalidSBOM bool
+		name            string
+		image           string
+		platform        string
+		invalidSBOM     bool
+		errorContaining string
 	}{
 		{
 			// Modern Ghost image with an SBOM attached in the Docker style.
-			name:  "Ghost",
-			image: "ghost:5.75.0-alpine",
+			name:     "Ghost",
+			image:    "ghost:5.75.0-alpine",
+			platform: "linux/amd64",
 		},
 		{
 			// Example from the Docker docs:
 			// https://github.com/docker/buildx/blob/5b5c4c8c9df55e133c39cce8153e0fa9fc6f60c4/docs/reference/buildx_imagetools_inspect.md
+			// This image has a Docker-style SBOM but is not multi-arch.
 			name:  "CrazyMaxBuildkit",
 			image: "index.docker.io/crazymax/buildkit@sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19",
+		},
+		{
+			// Example from the Docker docs:
+			// https://github.com/docker/buildx/blob/5b5c4c8c9df55e133c39cce8153e0fa9fc6f60c4/docs/reference/buildx_imagetools_inspect.md
+			// This image has a Docker-style SBOM but is not multi-arch.
+			name:            "CrazyMaxBuildkitNoSuchArch",
+			image:           "index.docker.io/crazymax/buildkit@sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19",
+			platform:        "linux/arm64",
+			errorContaining: "no runnable images match platform: linux/arm64",
 		},
 		{
 			// A random older (late 2022) Chainguard static base image with a .sbom
@@ -32,36 +45,60 @@ func TestLoadSBOM(t *testing.T) {
 			name:        "ChainguardStaticOld",
 			image:       "cgr.dev/chainguard/static@sha256:3d7a2b4e485b98ffc9a8dc10a7c8bc82bc235f72cf166abb8058e5a65648c500",
 			invalidSBOM: true,
+			platform:    "linux/amd64",
 		},
 		{
 			// A newer (late 2023) Chainguard static base image with a .att attestation,
 			// but not .sbom.
-			name:  "ChainguardStaticModern",
-			image: "cgr.dev/chainguard/static@sha256:606b571cf58a1f29a65ed4a09973b02664ce61a1325e8295f9ab1e38a1ac0632",
+			name:     "ChainguardStaticModern",
+			image:    "cgr.dev/chainguard/static@sha256:606b571cf58a1f29a65ed4a09973b02664ce61a1325e8295f9ab1e38a1ac0632",
+			platform: "linux/amd64",
 		},
 		{
 			// Unpinned Chainguard static base image.
-			name:  "ChainguardLatest",
-			image: "cgr.dev/chainguard/static",
+			name:     "ChainguardLatest",
+			image:    "cgr.dev/chainguard/static",
+			platform: "linux/amd64",
+		},
+		{
+			// Unpinned Chainguard static base image -
+			name:            "ChainguardStaticResolveFailure",
+			image:           "cgr.dev/chainguard/static@sha256:ab062ebcd496faecdec3961b0e8061d81ce1553595432a7e6d212ff2c3bd46d8",
+			errorContaining: "found multiple matching images in index: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le, linux/s390x",
 		},
 		{
 			// Unpinned Distroless static base image.
-			name:  "DistrolessStaticLatest",
-			image: "gcr.io/distroless/static",
+			name:     "DistrolessStaticLatest",
+			image:    "gcr.io/distroless/static",
+			platform: "linux/amd64",
 		},
 		{
 			// Unpinned rekor-server image.
-			name:  "GCRRekor",
-			image: "gcr.io/projectsigstore/rekor-server:v1.3.4",
+			name:     "GCRRekor",
+			image:    "gcr.io/projectsigstore/rekor-server:v1.3.4",
+			platform: "linux/amd64",
+		},
+		{
+			// A modern Docker style image which has an SBOM but only supports ARM
+			name:  "ARMOnly",
+			image: "edgebitio/arm-test:latest",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			loader := NewDefaultRegistryLoader(ctx)
+			loader, err := NewDefaultRegistryLoader(ctx, RegistryLoaderArgs{
+				Platform: tt.platform,
+			})
+			require.NoError(t, err)
 
 			data, err := loader.Load(ctx, tt.image)
+			if tt.errorContaining != "" {
+				require.ErrorContains(t, err, tt.errorContaining)
+				return
+			}
+
 			require.NoError(t, err)
 
 			sbom, format, err := formats.Decode(data)


### PR DESCRIPTION
Currently when resolving an OCI image, if we encounter an Image Index the client is hardcoded (by way of a crane default) to look for a `linux/amd64` image. It's typically possible to work around this by pointing the client directly at the platform-specific image, but this doesn't work for Docker-style SBOMs because the SBOM reference is actually stored in the Image Index.

This PR introduces a new `--resolve-platform` flag, which acts as a filter on images we encounter in indexes.

If, after applying this filter, more than one image still remains, we return an error listing out which platforms were found.

So there are now basically two modes of operation:

1. Point the CLI at a single-platform image or index
2. Point the CLI at a multi-platform index, and specify a `--resolve-platform` filter

It should be noted that this will break anyone who currently has the CLI pointed at a multi-platform index, but since that functionality is less than 24 hours old I'm inclined to ignore this.