### PR TITLE
Pick up a newer version of Syft to test improved Go.mod replace logic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             {
               "pr-number": "${{ github.event.number }}",
               "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}",
-              commit-sha: ${{github.sha}}
+              "commit-sha": "${{github.sha}}"
             }
           EOF
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,8 @@ jobs:
           cat > /tmp/metadata.json <<EOF
             {
               "pr-number": "${{ github.event.number }}",
-              "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}"
+              "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}",
+              commit-sha: ${{github.sha}}
             }
           EOF
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Run GoReleaser
         id: goreleaser
@@ -35,6 +35,7 @@ jobs:
           artifact-name: sbom.spdx.json
           upload-artifact: true
           config: .github/edgebit/source-syft.yaml
+          syft-version: v1.5.0
 
       - name: Write out the metadata
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,10 +29,6 @@ jobs:
         with:
           go-version: "1.21.5"
 
-      - name: Download Syft
-        id: syft
-        uses: anchore/sbom-action/download-syft@v0.14.2
-
       - name: Run GoReleaser
         id: goreleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
1. Remove un-used Syft action in release step
2. Temporarily pin to Syft 1.5.0 (action hasn't bumped the default version) to test improved Go.mod replace logic https://github.com/anchore/syft/pull/2891