### PR TITLE
build: wrap artifacts in directory

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,7 @@ archives:
     format_overrides:
     - goos: windows
       format: zip
+    wrap_in_directory: true
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
It's considered best practice to nest release artifacts in a directory before archiving the result. When users extract the archive, it keeps the artifacts together and labels them with their version number. This is especially helpful when multiple versions are present.